### PR TITLE
[WIP] feat: added config for i18n

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -47,7 +47,11 @@ const config = {
             href: 'https://github.com/UlisesGascon/secure-nodejs-guidelines',
             label: 'GitHub',
             position: 'right'
-          }
+          },
+          {
+            type: 'localeDropdown',
+            position: 'left',
+          },
         ]
       },
       footer: {
@@ -58,7 +62,20 @@ const config = {
         theme: lightCodeTheme,
         darkTheme: darkCodeTheme
       }
-    })
+    }),
+
+  i18n: {
+    defaultLocale: 'en',
+    locales: ['en', 'es'],
+    localeConfigs: {
+      en: {
+        label: 'English',
+      },
+      es: {
+        label: 'Español',
+      },
+    },
+  },
 }
 
 module.exports = config

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
+    "start:spanish": "npm run start -- --locale es",
     "start": "docusaurus start",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",


### PR DESCRIPTION
### Main changes

- Added i18n setup for Spanish. Defined English as the default language

### Next steps

Clone the current content to ES translation folder and start the translation
```bash
mkdir -p i18n/es/docusaurus-plugin-content-docs/current
cp -r docs/** i18n/es/docusaurus-plugin-content-docs/current
```